### PR TITLE
Default values and BareURN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ logs
 results
 
 npm-debug.log
-
+node_modules/
 *.pydevproject
 .project
 .metadata

--- a/docs/hOptions.md
+++ b/docs/hOptions.md
@@ -19,7 +19,7 @@ Endpoint of the hNode. Expects an array from which one will be chosen randomly. 
 hOptions["endpoints"] = <String[]>
 ```
 
-`Default Value: ["http://localhost:5280/http-bind"]`
+`Default Value: ["http://localhost:8080"]`
 
 ## Timeout
 Time to wait (ms) while connecting to the hNode. If it doesn't respond in that interval an error will be passed to callback.

--- a/examples/node/connectionOptions.js
+++ b/examples/node/connectionOptions.js
@@ -42,9 +42,9 @@ hClient.onMessage = function(hMessage){
 hClient.onStatus = function(hStatus){
     console.log('New Status', hStatus);
 
-    if(hStatus == hClient.statuses.CONNECTED)
+    if(hStatus.status == hClient.statuses.CONNECTED)
         console.log('You are connected, now you can execute commands. Look at the browser example!');
 };
 
-// Starts a connection to the XMPP Server using passed options.
-hClient.connect('publisher', 'password', hOptions);
+// Starts a connection to the running topology using passed options.
+hClient.connect('urn:localhost:user', 'urn:localhost:user', hOptions);

--- a/hubiquitus.js
+++ b/hubiquitus.js
@@ -352,17 +352,51 @@ define(
                 return this.buildMessage(actor, 'hConvState', {status: status}, options);
             },
 
-            checkURN: function(urn){
-                return /(^urn:[a-zA-Z0-9]{1}[a-zA-Z0-9\-.]+:[a-zA-Z0-9_,=@;!'%/#\(\)\+\-\.\$\*\?]+\/?.+$)/.test(urn);
+            // checkURN: function(urn){
+            //     return /(^urn:[a-zA-Z0-9]{1}[a-zA-Z0-9\-.]+:[a-zA-Z0-9_,=@;!'%/#\(\)\+\-\.\$\*\?]+\/?.+$)/.test(urn);
+            // },
+
+            // splitURN: function(urn){
+            //     return urn.split(":").splice(1, 3);
+            // },
+
+            // bareURN: function(urn) {
+            //     var urnParts = this.splitURN(urn);
+            //     return "urn:" + urnParts[0] + ":" + urnParts[1];
+            // },
+
+            validateFullURN: function(urn) {
+              return /(^urn:[a-zA-Z0-9]{1}[a-zA-Z0-9\-.]+:[a-zA-Z0-9_,=@;!'%/#\(\)\+\-\.\$\*\?]+\/.+$)/.test(urn);
             },
 
-            splitURN: function(urn){
-                return urn.split(":").splice(1, 3);
+            splitURN:function(urn) {
+              var splitted;
+
+              if (typeof urn === "string") {
+                splitted = urn.split(":");
+              }
+              if (splitted) {
+                if (this.validateFullURN(urn)) {
+                  splitted[3] = splitted[2].replace(/(^[^\/]*\/)/, "");
+                  splitted[2] = splitted[2].replace(/\/.*$/g, "");
+                }
+                return splitted.splice(1, 3);
+              } else {
+                return [undefined, undefined, undefined];
+              }
             },
 
+            getBareURN: function(urn) {
+              var urnParts;
+
+              urnParts = this.splitURN(urn);
+              return "urn:" + urnParts[0] + ":" + urnParts[1];
+            },
             bareURN: function(urn) {
-                var urnParts = this.splitURN(urn);
-                return "urn:" + urnParts[0] + ":" + urnParts[1];
+              var urnParts;
+
+              urnParts = this.splitURN(urn);
+              return "urn:" + urnParts[0] + ":" + urnParts[1];
             },
 
             errors: codes.errors,

--- a/hubiquitus.js
+++ b/hubiquitus.js
@@ -352,19 +352,6 @@ define(
                 return this.buildMessage(actor, 'hConvState', {status: status}, options);
             },
 
-            // checkURN: function(urn){
-            //     return /(^urn:[a-zA-Z0-9]{1}[a-zA-Z0-9\-.]+:[a-zA-Z0-9_,=@;!'%/#\(\)\+\-\.\$\*\?]+\/?.+$)/.test(urn);
-            // },
-
-            // splitURN: function(urn){
-            //     return urn.split(":").splice(1, 3);
-            // },
-
-            // bareURN: function(urn) {
-            //     var urnParts = this.splitURN(urn);
-            //     return "urn:" + urnParts[0] + ":" + urnParts[1];
-            // },
-
             validateFullURN: function(urn) {
               return /(^urn:[a-zA-Z0-9]{1}[a-zA-Z0-9\-.]+:[a-zA-Z0-9_,=@;!'%/#\(\)\+\-\.\$\*\?]+\/.+$)/.test(urn);
             },
@@ -392,6 +379,8 @@ define(
               urnParts = this.splitURN(urn);
               return "urn:" + urnParts[0] + ":" + urnParts[1];
             },
+
+            // Deprecated : This function is here for retro compatiblity.
             bareURN: function(urn) {
               var urnParts;
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -42,10 +42,10 @@ define(
                 timeout : opts.timeout || 15000,
 
                 //Transport to connect to the hNode
-                transport : opts.transport,
+                transport : opts.transport || ['socketio'],
 
                 //Endpoint of the hNode. A random will be chosen from the array
-                endpoints : opts.endpoints || ['http://localhost:5280/http-bind'],
+                endpoints : opts.endpoints || ['http://localhost:8080'],
 
                 //If this option is set, several connections are allowed and reattach is
                 //not possible anymore

--- a/package.json
+++ b/package.json
@@ -19,4 +19,8 @@
     }
   , "main": "hubiquitus"
   , "engines": { "node": ">= 0.8.0" }
+  , "scripts": {
+      "test": "mocha --compilers coffee:coffee-script -R spec test/*"
+  }
+
 }


### PR DESCRIPTION
In this pull request :
- Default http set to http://localhost:8080
- Function bareURN, splitURN, validateFullURN now remove the id part of the urn
- Command 'npm test' was added in package.json
- minor Fixes in example/connectionOptions.js

I can't run test on hubiquitus4js. 
Do I have to run hubiquitus4js against a specific topology ?
